### PR TITLE
Dynamic download folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ const register = (opts = {}) => {
 
 const download = (options, callback) => {
     let win = BrowserWindow.getFocusedWindow() || lastWindowCreated;
-    options = Object.assign({}, { path: '' }, options);
+    options = Object.assign({}, { path: '', downloadFolder }, options);
 
     const request = net.request(options.url);
 
@@ -110,7 +110,7 @@ const download = (options, callback) => {
             onProgress: options.onProgress
         });
 
-        const filePath = path.join(path.join(downloadFolder, options.path.toString()), filename);
+        const filePath = path.join(path.join(options.downloadFolder, options.path.toString()), filename);
 
         if (fs.existsSync(filePath)) {
             const stats = fs.statSync(filePath);

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function _registerListener(win, opts = {}) {
         let queueItem = _popQueueItem(itemUrl);
 
         if (queueItem) {
-
-            const filePath = path.join(downloadFolder, path.join(queueItem.path, itemFilename));
+            const folder = queueItem.downloadFolder || downloadFolder
+            const filePath = path.join(folder, queueItem.path, itemFilename);
 
             const totalBytes = item.getTotalBytes();
 
@@ -92,7 +92,7 @@ const register = (opts = {}) => {
 
 const download = (options, callback) => {
     let win = BrowserWindow.getFocusedWindow() || lastWindowCreated;
-    options = Object.assign({}, { path: '', downloadFolder }, options);
+    options = Object.assign({}, { path: '' }, options);
 
     const request = net.request(options.url);
 
@@ -105,12 +105,14 @@ const download = (options, callback) => {
         queue.push({
             url: url,
             filename: filename,
+            downloadFolder: options.downloadFolder,
             path: options.path.toString(),
             callback: callback,
             onProgress: options.onProgress
         });
 
-        const filePath = path.join(path.join(options.downloadFolder, options.path.toString()), filename);
+        const folder = options.downloadFolder || downloadFolder
+        const filePath = path.join(folder, options.path.toString(), filename)
 
         if (fs.existsSync(filePath)) {
             const stats = fs.statSync(filePath);


### PR DESCRIPTION
This PR allows the user to set the `downloadFolder` on `download` method. There are some cases where the user sets this attribute dynamically, so is not enough to just have a default (set on the register method).
It also removes some redundant `path.join` calls.