### PR TITLE
add electron to dev dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/danielnieto/electron-download-manager/issues"
   },
   "homepage": "https://github.com/danielnieto/electron-download-manager#readme",
-  "dependencies": {
+  "devDependencies": {
     "electron": ">=1.4.12"
   }
 }


### PR DESCRIPTION
I think electron should be in devDependencies not dependencies otherwise you will get version mismatches when using packages like electron-debug, electron-builder, etc.