### PR TITLE
add preference for first of any redirect url chains for queue lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function _registerListener(win, opts = {}) {
 
     const listener = (e, item) => {
 
-        const itemUrl = decodeURIComponent(item.getURL());
+        const itemUrl = decodeURIComponent(item.getURLChain()[0] || item.getURL())
         const itemFilename = decodeURIComponent(item.getFilename());
 
         let queueItem = _popQueueItem(itemUrl);


### PR DESCRIPTION
Was recently checking out the electron-download-manager package (extremely useful, btw). I ended up running into a problem with the onProgress argument not displaying anything, the same as this issue here:

https://github.com/danielnieto/electron-download-manager/issues/12

While it seems that some of these users are having some kind of binding issue, I suspect I have a solution for the other half. (For the record, this did allow me to get the progress for the rendering side as well--literally inside a React component.)

I went through the source and realized that my download url (which we use to pop from the queue) is getting changed, so the queue pop returns nothing. This is because of inherent redirects (I was using a DropBox link).

Luckily there was a very simple solution built-in by electronJS's `downloadItem` class.

Cheers!

