### PR TITLE
Prevent memory leaks from .on() when register called multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 
 const app = electron.app;
 let downloadFolder = app.getPath('downloads');
+let moduleOptions = {};
 let lastWindowCreated;
 
 const queue = [];
@@ -120,15 +121,16 @@ function _registerListener(win, opts = {}) {
             });
         }
     };
-
+    win.webContents.session.off('will-download', listener);
     win.webContents.session.on('will-download', listener);
 }
-
+const windowListener = function (e, win) {
+    _registerListener(win, moduleOptions);
+}
 const register = (opts = {}) => {
-
-    app.on('browser-window-created', (e, win) => {
-        _registerListener(win, opts);
-    });
+    moduleOptions = opts;    
+    app.off('browser-window-created', windowListener);
+    app.on('browser-window-created', windowListener);
 };
 
 const download = (options, callback) => {


### PR DESCRIPTION
In my current application, the user can select a download location. This can be updated many times in a single session. Due to being unable to update the path once a handler is registered, I have resorted to calling DownloadManager.register to update the path. The existing code causes multiple handlers to be registered when calling DownloadManager.register multiple times.

This causes the following output from node:

```
(node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 browser-window-created listeners added to [App]. Use emitter.setMaxListeners() to increase limit
    at _addListener (events.js:390:17)
    at App.addListener (events.js:406:10)
    ...

```

A more permanent solution would be an API to allow the update of the options parameter, but the module still should not cause this behaviour if used incorrectly. This PR fixes that behaviour. 